### PR TITLE
Fix crash after GMX, update SDK and introduce new config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install CMake
-        uses: lukka/get-cmake@v3.23.2
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.23.2'
 
       - name: Generate build files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build-windows-release:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           clean: true
           submodules: recursive
@@ -32,7 +32,7 @@ jobs:
           cmake --build . --config Release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sampvoice-win-release
           path: build/server/Release/sampvoice.dll
@@ -40,7 +40,7 @@ jobs:
   build-linux-release:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           clean: true
           submodules: recursive
@@ -61,7 +61,7 @@ jobs:
           cmake --build . --config Release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sampvoice-linux-release
           path: build/server/sampvoice.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install CMake
-        uses: lukka/get-cmake@v.3.23.2
+        uses: lukka/get-cmake@v3.23.2
 
       - name: Generate build files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install packages
-        run: sudo apt-get install g++-multilib
+        run: sudo apt-get update && sudo apt-get install g++-multilib --fix-missing
 
       - name: Install CMake
         uses: lukka/get-cmake@v.3.23.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,8 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-
       - name: Install CMake
         uses: lukka/get-cmake@v.3.23.2
-
-      - name: Install latest conan
-        run: |
-          python -m pip install --upgrade pip
-          pip install conan
 
       - name: Generate build files
         run: |
@@ -46,7 +38,7 @@ jobs:
           path: build/server/Release/sampvoice.dll
 
   build-linux-release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,16 +49,8 @@ jobs:
       - name: Install packages
         run: sudo apt-get install g++-multilib
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-
       - name: Install CMake
         uses: lukka/get-cmake@v.3.23.2
-
-      - name: Install latest conan
-        run: |
-          python -m pip install --upgrade pip
-          pip install conan
 
       - name: Generate build files
         run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           path: build/server/Release/sampvoice.dll
 
   build-linux-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,22 +46,15 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install g++-multilib --fix-missing
-
-      - name: Install CMake
-        uses: lukka/get-cmake@v.3.23.2
-
-      - name: Generate build files
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32
-
       - name: Build
         run: |
-          cd build
-          cmake --build . --config Release
+          cd docker
+          chmod +x ./build.sh
+          chmod +x ./docker-entrypoint.sh
+          ./build.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: sampvoice-linux-release
-          path: build/server/sampvoice.so
+          path: docker/build/server/sampvoice.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           clean: true
           submodules: recursive
-          token: ${{ secrets.CI_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Python
@@ -53,7 +52,6 @@ jobs:
         with:
           clean: true
           submodules: recursive
-          token: ${{ secrets.CI_TOKEN }}
           fetch-depth: 0
 
       - name: Install packages

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Players can be both speakers and listeners at the same time. In this case, the p
 #### Example
 ---------------------------------
 Let's take a look at some of the plugin's features with a practical example. Below we will create a server that will bind all connected players to the global stream, and also create a local stream for each player. Thus, players will be able to communicate through the global (heard equally at any point on the map) and local (heard only near the player) chats.
-```php
+```cpp
 #include <sampvoice>
 
 new SV_GSTREAM:gstream = SV_NULL;
@@ -127,6 +127,8 @@ public OnPlayerDisconnect(playerid, reason)
     // Removing the player's local stream after disconnecting
     if (lstream[playerid])
     {
+        SvDetachListenerFromStream(lstream[playerid], playerid);
+        SvDetachSpeakerFromStream(lstream[playerid], playerid);
         SvDeleteStream(lstream[playerid]);
         lstream[playerid] = SV_NULL;
     }
@@ -142,7 +144,16 @@ public OnGameModeInit()
 
 public OnGameModeExit()
 {
-    if (gstream) SvDeleteStream(gstream);
+    if (gstream)
+    {
+        for (new i = 0; i < MAX_PLAYERS; i ++)
+        {
+            if (!IsPlayerConnected(i)) continue;
+            SvDetachListenerFromStream(gstream, i);
+            SvDetachSpeakerFromStream(gstream, i);
+        }
+        SvDeleteStream(gstream);
+    }
 }
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04
+RUN \
+    dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+        gpg \
+        wget \
+    && \
+    wget -O- https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
+    gpg --dearmor - | \
+    tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | \
+    tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    apt-get update && \
+    apt-get install -y \
+        cmake \
+        ninja-build \
+        g++-multilib \
+        libstdc++6:i386 \
+        libc6:i386 \
+    && \
+    useradd -m user
+
+USER user
+
+ENV PATH=~/.local/bin:${PATH}
+
+COPY docker-entrypoint.sh /
+CMD /docker-entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 RUN \
     dpkg --add-architecture i386 && \
     apt-get update && \
@@ -14,7 +14,6 @@ RUN \
     apt-get update && \
     apt-get install -y \
         cmake \
-        ninja-build \
         g++-multilib \
         libstdc++6:i386 \
         libc6:i386 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN \
     dpkg --add-architecture i386 && \
     apt-get update && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Available configs: Debug, RelWithDebInfo, [Release]
+[[ -z "$CONFIG" ]] \
+&& config=Release \
+|| config="$CONFIG"
+
+docker build \
+    -t omp-voice/build:ubuntu-18.04 ./ \
+|| exit 1
+
+folders=('build')
+for folder in "${folders[@]}"; do
+    if [[ ! -d "./${folder}" ]]; then
+        mkdir ${folder}
+    fi
+    sudo chown -R 1000:1000 ${folder} || exit 1
+done
+
+docker run \
+    --rm \
+    -t \
+    -w /code \
+    -v $PWD/..:/code \
+    -v $PWD/build:/code/build \
+    -e CONFIG=${config} \
+    omp-voice/build:ubuntu-18.04

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+[ -z $CONFIG ] && config=Release || config="$CONFIG"
+
+cmake \
+    -S . \
+    -B build \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=$config \
+&&
+cmake \
+    --build build \
+    --config $config \
+    --parallel $(nproc)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,9 +2,11 @@
 [ -z $CONFIG ] && config=Release || config="$CONFIG"
 
 cmake \
-    -S . \
+    -S .. \
     -B build \
-    -G Ninja \
+    -DCMAKE_BUILD_TYPE=$config \
+    -DCMAKE_C_FLAGS=-m32 \
+    -DCMAKE_CXX_FLAGS=-m32 \
     -DCMAKE_BUILD_TYPE=$config \
 &&
 cmake \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 [ -z $CONFIG ] && config=Release || config="$CONFIG"
 
 cmake \
-    -S .. \
+    -S . \
     -B build \
     -DCMAKE_BUILD_TYPE=$config \
     -DCMAKE_C_FLAGS=-m32 \

--- a/server/DynamicLocalStreamAtPlayer.cpp
+++ b/server/DynamicLocalStreamAtPlayer.cpp
@@ -53,7 +53,7 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID == player->getID()))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID != INVALID_PLAYER_ID))
 			{
 				if (distanceToPlayer <= distance)
 				{
@@ -91,7 +91,7 @@ void DynamicLocalStreamAtPlayer::Tick()
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID == player->getID()))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID != player->getID()))
 			{
 				if (distanceToPlayer <= streamDistance)
 				{

--- a/server/DynamicLocalStreamAtPlayer.cpp
+++ b/server/DynamicLocalStreamAtPlayer.cpp
@@ -41,7 +41,6 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->distance = distance;
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->target = playerId;
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->color = color;
-	bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_streamed_in");
 
 	IPlayer* player = SampVoiceComponent::GetPlayers()->get(playerId);
 	if (player != nullptr)
@@ -54,7 +53,7 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && ((checkForStreamIn && other->isStreamedInForPlayer(*player)) || !checkForStreamIn))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID == player->getID()))
 			{
 				if (distanceToPlayer <= distance)
 				{
@@ -87,13 +86,12 @@ void DynamicLocalStreamAtPlayer::Tick()
 
 		const Vector3& streamPosition = player->getPosition();
 		const float streamDistance = PackGetStruct(&*this->packetStreamUpdateDistance, SV::UpdateLStreamDistancePacket)->distance;
-		bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_streamed_in");
 
 		for (IPlayer* other : PlayerStore::internalPlayerPool)
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && ((checkForStreamIn && other->isStreamedInForPlayer(*player)) || !checkForStreamIn))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID == player->getID()))
 			{
 				if (distanceToPlayer <= streamDistance)
 				{

--- a/server/DynamicLocalStreamAtPlayer.cpp
+++ b/server/DynamicLocalStreamAtPlayer.cpp
@@ -41,7 +41,7 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->distance = distance;
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->target = playerId;
 	PackGetStruct(&*this->packetCreateStream, SV::CreateLStreamAtPacket)->color = color;
-	bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_stream_in");
+	bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_streamed_in");
 
 	IPlayer* player = SampVoiceComponent::GetPlayers()->get(playerId);
 	if (player != nullptr)
@@ -53,17 +53,8 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 		for (IPlayer* other : PlayerStore::internalPlayerPool)
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
-			if (checkForStreamIn)
-			{	
-				if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && other->isStreamedInForPlayer(*player))
-				{
-					if (distanceToPlayer <= distance)
-					{
-						playerList.emplace(distanceToPlayer, other->getID());
-					}
-				}
-			}
-			else
+
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && ((checkForStreamIn && other->isStreamedInForPlayer(*player)) || !checkForStreamIn))
 			{
 				if (distanceToPlayer <= distance)
 				{
@@ -96,34 +87,13 @@ void DynamicLocalStreamAtPlayer::Tick()
 
 		const Vector3& streamPosition = player->getPosition();
 		const float streamDistance = PackGetStruct(&*this->packetStreamUpdateDistance, SV::UpdateLStreamDistancePacket)->distance;
-		bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_stream_in");
+		bool checkForStreamIn = SampVoiceComponent::instance->GetSampVoiceConfigBool("sampvoice.check_for_streamed_in");
 
 		for (IPlayer* other : PlayerStore::internalPlayerPool)
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (checkForStreamIn)
-			{
-				if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && other->isStreamedInForPlayer(*player))
-				{
-					if (distanceToPlayer <= streamDistance)
-					{
-						if (!this->HasListener(other->getID()))
-						{
-							playerList.emplace(distanceToPlayer, other->getID());
-						}
-					}
-					else if (this->HasListener(other->getID()))
-					{
-						this->Stream::DetachListener(other->getID());
-					}
-				}
-				else if (this->HasListener(other->getID()))
-				{
-					this->Stream::DetachListener(other->getID());
-				}
-			}
-			else
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && ((checkForStreamIn && other->isStreamedInForPlayer(*player)) || !checkForStreamIn))
 			{
 				if (distanceToPlayer <= streamDistance)
 				{
@@ -136,6 +106,10 @@ void DynamicLocalStreamAtPlayer::Tick()
 				{
 					this->Stream::DetachListener(other->getID());
 				}
+			}
+			else if (this->HasListener(other->getID()))
+			{
+				this->Stream::DetachListener(other->getID());
 			}
 		}
 

--- a/server/DynamicLocalStreamAtVehicle.cpp
+++ b/server/DynamicLocalStreamAtVehicle.cpp
@@ -52,7 +52,7 @@ DynamicLocalStreamAtVehicle::DynamicLocalStreamAtVehicle(
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID == vehicle->getID()))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID != INVALID_VEHICLE_ID))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= distance) 
@@ -90,7 +90,7 @@ void DynamicLocalStreamAtVehicle::Tick()
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID == vehicle->getID()))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID != INVALID_VEHICLE_ID))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= streamDistance)

--- a/server/DynamicLocalStreamAtVehicle.cpp
+++ b/server/DynamicLocalStreamAtVehicle.cpp
@@ -52,7 +52,7 @@ DynamicLocalStreamAtVehicle::DynamicLocalStreamAtVehicle(
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && vehicle->isStreamedInForPlayer(*player))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID == vehicle->getID()))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= distance) 
@@ -90,7 +90,7 @@ void DynamicLocalStreamAtVehicle::Tick()
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && vehicle->isStreamedInForPlayer(*player))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID == vehicle->getID()))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= streamDistance)

--- a/server/Header.h
+++ b/server/Header.h
@@ -235,6 +235,7 @@ public:
 	static IVehiclesComponent* GetVehicles() { return instance->vehiclesComponent; }
 	static IObjectsComponent* GetObjects() { return instance->objectsComponent; }
 	static int GetSampVoiceConfigInt(StringView key);
+	static bool GetSampVoiceConfigBool(StringView key);
 
 	StringView componentName() const override { return "sampvoice open.mp port"; }
 

--- a/server/Header.h
+++ b/server/Header.h
@@ -254,7 +254,7 @@ public:
 	void onInit(IComponentList* components) override;
 	void onTick(Microseconds elapsed, TimePoint now) override;
 	void onAmxLoad(IPawnScript& script) override;
-	void onAmxUnload(IPawnScript& script) override { };
+	void onAmxUnload(IPawnScript& script) override;
 	void onFree(IComponent* component) override;
 	void reset() override {}
 

--- a/server/Pawn.cpp
+++ b/server/Pawn.cpp
@@ -105,10 +105,16 @@ void Pawn::RegisterScript(AMX* const amx)
 	Pawn::scripts.emplace_back(amx);
 }
 
+void Pawn::UnregisterScript(AMX* const amx)
+{
+	Pawn::scripts.erase(std::remove_if(Pawn::scripts.begin(), Pawn::scripts.end(), [&](AMX* val) {
+		return val == amx;
+	}), Pawn::scripts.end());
+}
+
 void Pawn::OnPlayerActivationKeyPressForAll(const uint16_t playerid, const uint8_t keyid) noexcept
 {
 	if (Pawn::pInterface == nullptr) return;
-
 
 	for (const auto& script : Pawn::scripts)
 	{

--- a/server/Pawn.h
+++ b/server/Pawn.h
@@ -277,6 +277,7 @@ public:
 	static void Free() noexcept;
 
 	static void RegisterScript(AMX* amx);
+	static void UnregisterScript(AMX* amx);
 
 	static void OnPlayerActivationKeyPressForAll(uint16_t playerid, uint8_t keyid) noexcept;
 	static void OnPlayerActivationKeyReleaseForAll(uint16_t playerid, uint8_t keyid) noexcept;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -862,13 +862,39 @@ void SampVoiceComponent::onFree(IComponent* component)
 bool SampVoiceComponent::GetSampVoiceConfigBool(StringView key)
 {
 	ICore* ompCore = SampVoiceComponent::GetCore();
+	bool value = true;
 	if (ompCore)
 	{
-		bool* ompConfigValue = ompCore->getConfig().getBool(key);
-
-		return *ompConfigValue;
+		bool ompConfigValue = (ompCore->getConfig().getBool(key)) ? (*ompCore->getConfig().getBool(key)) : false;
+		
+		if (!ompConfigValue)
+		{
+			try
+			{
+				std::ifstream file("server.cfg");
+				if (file.is_open())
+				{
+					std::string line;
+					while (std::getline(file, line))
+					{
+						if (line.find(Impl::String(key)) == 0)
+						{
+							value = atoi(line.substr(key.length() + 1).c_str());
+						}
+					}
+				}
+			}
+			catch (...)
+			{
+				value = true;
+			}
+		}
+		else
+		{
+			value = ompConfigValue;
+		}
 	}
-	return true;
+	return value;
 }
 
 int SampVoiceComponent::GetSampVoiceConfigInt(StringView key)

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -854,6 +854,18 @@ void SampVoiceComponent::onFree(IComponent* component)
 	}
 }
 
+bool SampVoiceComponent::GetSampVoiceConfigBool(StringView key)
+{
+	ICore* ompCore = SampVoiceComponent::GetCore();
+	if (ompCore)
+	{
+		bool* ompConfigValue = ompCore->getConfig().getBool(key);
+
+		return *ompConfigValue;
+	}
+	return true;
+}
+
 int SampVoiceComponent::GetSampVoiceConfigInt(StringView key)
 {
 	ICore* ompCore = SampVoiceComponent::GetCore();

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -815,6 +815,11 @@ void SampVoiceComponent::onAmxLoad(IPawnScript& script)
 	Pawn::RegisterScript(script.GetAMX());
 }
 
+void SampVoiceComponent::onAmxUnload(IPawnScript& script)
+{
+	Pawn::UnregisterScript(script.GetAMX());
+}
+
 void SampVoiceComponent::onFree(IComponent* component)
 {
 	if (component == pawnComponent || component == this)


### PR DESCRIPTION
This PR contains a fix for crash after GMX (the server will crash if someone presses a vc button after GMX) and updated to latest open.mp SDK.

Also introduces new config: `sampvoice.check_for_streamed_in`.
This config allows to skip the check for streamed in players and allows to hear streamed out players while spectating them (issue: #9).

open.mp config.json:
- default: `true`
```json
"sampvoice": {
    "check_for_streamed_in": true
},
```

samp's server.cfg:
- default: `true`
- accepted values: `true`, `false`, `1`, and `0`.
```cfg
sampvoice.check_for_streamed_in true
```