### PR TITLE
remove check if the player/vehicle is streamed in or not

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-windows-release:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +30,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A Win32
+          cmake -DCMAKE_BUILD_TYPE=Release .. -A Win32
           cmake --build . --config Release
 
       - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-windows-release:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +30,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 16 2019" -A Win32
+          cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A Win32
           cmake --build . --config Release
 
       - name: Upload artifacts

--- a/server/DynamicLocalStreamAtPlayer.cpp
+++ b/server/DynamicLocalStreamAtPlayer.cpp
@@ -53,7 +53,7 @@ DynamicLocalStreamAtPlayer::DynamicLocalStreamAtPlayer(
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID != INVALID_PLAYER_ID))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()))
 			{
 				if (distanceToPlayer <= distance)
 				{
@@ -91,7 +91,7 @@ void DynamicLocalStreamAtPlayer::Tick()
 		{
 			float distanceToPlayer = glm::distance(other->getPosition(), streamPosition);
 
-			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()) && (other->isStreamedInForPlayer(*player) || other->getSpectateData().spectateID != player->getID()))
+			if (other != player && PlayerStore::IsPlayerHasPlugin(other->getID()))
 			{
 				if (distanceToPlayer <= streamDistance)
 				{

--- a/server/DynamicLocalStreamAtVehicle.cpp
+++ b/server/DynamicLocalStreamAtVehicle.cpp
@@ -52,7 +52,7 @@ DynamicLocalStreamAtVehicle::DynamicLocalStreamAtVehicle(
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID != INVALID_VEHICLE_ID))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= distance) 
@@ -90,7 +90,7 @@ void DynamicLocalStreamAtVehicle::Tick()
 
 		for (IPlayer* player : PlayerStore::internalPlayerPool)
 		{
-			if (PlayerStore::IsPlayerHasPlugin(player->getID()) && (vehicle->isStreamedInForPlayer(*player) || player->getSpectateData().spectateID != INVALID_VEHICLE_ID))
+			if (PlayerStore::IsPlayerHasPlugin(player->getID()))
 			{
 				float distanceToPlayer = glm::distance(player->getPosition(), streamPosition);
 				if (distanceToPlayer <= streamDistance)


### PR DESCRIPTION
This PR removes the isStreamed check for player/vehicle. The previous PR has a bug where it can hear the players near the player you are spectating but can't hear the player you are spectating.